### PR TITLE
Implement #empty? on DwollaV2::Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Changelog
 
+- **1.2.3** - Implement `#empty?` on `DwollaV2::Token` to allow it to be passed to ActiveRecord constructor.
 - **1.2.2** - Strip domain from URLs provided to `token.*` methods.
 - **1.2.1** - Update sandbox URLs from uat => sandbox.
 - **1.2.0** - Refer to Client :id as :key in docs/public APIs for consistency.

--- a/lib/dwolla_v2/token.rb
+++ b/lib/dwolla_v2/token.rb
@@ -7,7 +7,7 @@ module DwollaV2
     attr_reader :client, :access_token, :refresh_token, :expires_in, :scope, :app_id, :account_id
 
     delegate [:in_parallel] => :@conn
-    delegate [:reject] => :stringify_keys
+    delegate [:reject, :empty?] => :stringify_keys
 
     def initialize client, params
       @client = client

--- a/lib/dwolla_v2/version.rb
+++ b/lib/dwolla_v2/version.rb
@@ -1,3 +1,3 @@
 module DwollaV2
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end

--- a/spec/dwolla_v2/token_spec.rb
+++ b/spec/dwolla_v2/token_spec.rb
@@ -125,6 +125,16 @@ describe DwollaV2::Token do
     })
   end
 
+  it "#empty? forwards to stringify_keys" do
+    token = DwollaV2::Token.new client, {}
+    expect(token.empty?).to be true
+  end
+
+  it "#empty? forwards to stringify_keys" do
+    token = DwollaV2::Token.new client, hash_params
+    expect(token.empty?).to be false
+  end
+
   it "#reject gets forwarded to #stringify_keys" do
     token = DwollaV2::Token.new client, hash_params
     expect(


### PR DESCRIPTION
Implement `#empty?` on `DwollaV2::Token` to allow it to be passed to ActiveRecord constructor.

https://github.com/rails/rails/blob/d1ca18d21f3c173af34dfdc3fa34de577178fee9/activemodel/lib/active_model/attribute_assignment.rb#L30 