### PR TITLE
Do not mutate the given URL on token

### DIFF
--- a/lib/dwolla_v2/token.rb
+++ b/lib/dwolla_v2/token.rb
@@ -77,7 +77,7 @@ module DwollaV2
 
     def self.full_url client, path
       path = path[:_links][:self][:href] if path.is_a? Hash
-      path.sub! /^https?:\/\/[^\/]*/, ""
+      path = path.sub /^https?:\/\/[^\/]*/, ""
       if path.start_with? client.api_url
         path
       elsif path.start_with? "/"

--- a/spec/dwolla_v2/token_spec.rb
+++ b/spec/dwolla_v2/token_spec.rb
@@ -271,6 +271,22 @@ describe DwollaV2::Token do
     end
   end
 
+  it "#post (do not mutate path)" do
+    token = DwollaV2::Token.new client, hash_params
+    path = "/foo"
+    res_body = {:hello => "world", :timestamp => Time.now.utc.round(3)}
+    stub_request(:post, "#{token.client.api_url}#{path}")
+      .with(:headers => {"Accept" => "application/vnd.dwolla.v1.hal+json"})
+      .to_return(:status => 200,
+                 :headers => {"Content-Type" => "application/json"},
+                 :body => generate_json(res_body))
+    path_variants(path).each do |path_variant|
+      path_variant_copy = path_variant.clone
+      expect(token.post path_variant).to eq res_body
+      expect(path_variant).to eq path_variant_copy
+    end
+  end
+
   it "#post (error)" do
     token = DwollaV2::Token.new client, hash_params
     path = "/foo"


### PR DESCRIPTION
Fix a problem caused by using the path after calling Dwolla methods.

Before:

```ruby
(test) DwollaService:0> x = "https://api-sandbox.dwolla.com/funding-sources/secret"
=> "https://api-sandbox.dwolla.com/funding-sources/secret"
(test) DwollaService:0> token.post(x)
=> #<DwollaV2::Response:0x3ff04d241bac>
(test) DwollaService:0> x
=> "/funding-sources/secret"
```

After:

```ruby
(test) DwollaService:0> x = "https://api-sandbox.dwolla.com/funding-sources/secret"
=> "https://api-sandbox.dwolla.com/funding-sources/secret"
(test) DwollaService:0> token.post(x)
=> #<DwollaV2::Response:0x3ff04d241bac>
(test) DwollaService:0> x
=> "https://api-sandbox.dwolla.com/funding-sources/secret"
```