### PR TITLE
Fix equality comparator of super hash with nil

### DIFF
--- a/lib/dwolla_v2/super_hash.rb
+++ b/lib/dwolla_v2/super_hash.rb
@@ -6,7 +6,7 @@ module DwollaV2
     include Hashie::Extensions::DeepFetch
 
     def == other
-      super(other) || super(self.class[other])
+      super(other) || other && super(self.class[other])
     end
   end
 end

--- a/spec/dwolla_v2/super_hash_spec.rb
+++ b/spec/dwolla_v2/super_hash_spec.rb
@@ -22,4 +22,10 @@ describe DwollaV2::SuperHash do
     super_hash = DwollaV2::Util.deep_super_hasherize(hash)
     expect(super_hash).to eq hash
   end
+
+  it "== works with nil values" do
+    hash = { a: { b: { c: "d" } } }
+    super_hash = DwollaV2::Util.deep_super_hasherize(hash)
+    expect(super_hash).not_to eq nil
+  end
 end


### PR DESCRIPTION
Fixes an `#<ArgumentError: odd number of arguments for Hash>` exception.

This will make the exceptions compatible to be reported by bug snag that compares them with nil [here](https://github.com/bugsnag/bugsnag-ruby/blob/7d4d29160a5c404f7c803cbec04e3f25361a5de8/lib/bugsnag/notification.rb#L78).