### PR TITLE
Require time lib otherwise `Time.iso8601` is undefined by default

### DIFF
--- a/lib/dwolla_v2.rb
+++ b/lib/dwolla_v2.rb
@@ -3,6 +3,7 @@ require "uri"
 require "json"
 require "forwardable"
 require "ostruct"
+require "time"
 
 require "hashie"
 


### PR DESCRIPTION
While I was working on the changes in #37 I noticed that the timestamps in responses remained as strings but I had already seen the middleware and knew it was supposed to be converted. The issue is that while I was in a `bundle console` the library is loaded as you have it defined but when using this in say a Rails app you wouldn't notice the issue as the time lib is already required by Rails. This just makes it a clear dependency here and now you'll see times being converted. Before the change it was: `"created"=>"2018-01-03T23:42:08.963Z"}` because `Time.iso8601` is an undefined but since it also had a `rescue` statement it was swallowing that error. Now including the changes in this PR it came out to: `"created"=>2018-01-03 23:42:08 UTC}` so you can see its being converted.