### PR TITLE
Add methods for OpenID

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ $dwolla = DwollaV2::Client.new(
 )
 ```
 
+### Integrations Authorization
+
+Check out our [Integrations Authorization Guide](https://developers.dwolla.com/integrations/authorization).
+
 ### Configure Faraday (optional)
 
 DwollaV2 uses [Faraday][faraday] to make HTTP requests. You can configure your own
@@ -183,6 +187,7 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Changelog
 
+- **3.0.0** - Add integrations auth functions
 - **3.0.0.beta1** - Add token management functionality to `DwollaV2::Client`
 - **2.2.1** - Update dependencies
 - **2.2.0** - Change token url from `www.dwolla.com/oauth/v2/token` to `accounts.dwolla.com/token`

--- a/lib/dwolla_v2/client.rb
+++ b/lib/dwolla_v2/client.rb
@@ -18,7 +18,7 @@ module DwollaV2
     attr_reader :id, :secret, :auths, :tokens
     alias_method :key, :id
 
-    def_delegators :token, :get, :post, :delete
+    def_delegators :current_token, :get, :post, :delete
 
     def initialize opts
       opts[:id] ||= opts[:key]
@@ -70,6 +70,21 @@ module DwollaV2
       end
     end
 
+    def auth(params = {})
+      DwollaV2::Auth.new(self, params)
+    end
+
+    def refresh_token(params = {})
+      unless params.is_a?(Hash) && params.has_key?(:refresh_token)
+        raise ArgumentError.new(":refresh_token is required")
+      end
+      auths.refresh(params, params)
+    end
+
+    def token(params = {})
+      tokens.new(params)
+    end
+
     def auth_url
       ENVIRONMENTS[environment][:auth_url]
     end
@@ -88,7 +103,7 @@ module DwollaV2
 
     private
 
-      def token
+      def current_token
         @token_manager.get_token
       end
   end

--- a/lib/dwolla_v2/version.rb
+++ b/lib/dwolla_v2/version.rb
@@ -1,3 +1,3 @@
 module DwollaV2
-  VERSION = "3.0.0.beta1"
+  VERSION = "3.0.0"
 end

--- a/spec/dwolla_v2/client_spec.rb
+++ b/spec/dwolla_v2/client_spec.rb
@@ -228,13 +228,17 @@ describe DwollaV2::Client do
 
   describe "openid methods" do
     let!(:client) { DwollaV2::Client.new(id: id, secret: secret) }
-    let!(:redirect_uri) { "redirect-uri" }
+    let!(:redirect_uri) { "https://redirect.uri/dwolla/callback" }
 
     it "#auth returns DwollaV2::Auth" do
       auth = client.auth(redirect_uri: redirect_uri)
       
       expect(auth).to be_a DwollaV2::Auth
-      expect(auth.redirect_uri).to eq redirect_uri
+      expect(auth.url).to eq "#{client.auth_url}?#{URI.encode_www_form(
+        response_type: "code",
+        client_id: client.id,
+        redirect_uri: redirect_uri
+      )}"
     end
 
     it "#refresh_token returns ArgumentError" do


### PR DESCRIPTION
### Auth flow

```ruby
auth = $dwolla.auth(redirect_uri: "https://mysite.com/dwolla/callback")
auth.url # => "https://accounts.dwolla.com/auth?response_type=code&client_id=my-client-id&redirect_uri=https%3A%2F%2Fmysite.com%2Fdwolla%2Fcallback"

token = auth.callback(code: "my-code")
token.access_token # => "access-token"
token.get("customers")
```

### Refresh flow

```ruby
new_token = $dwolla.refresh_token(refresh_token: old_token.refresh_token)
new_token.access_token # => "new-access-token"
new_token.get("customers")
```

### Instantiating a Token

```ruby
token = $dwolla.token(access_token: "access-token")
token.get("customers")
```