### PR TITLE
Update dwolla_v2.gemspec

### DIFF
--- a/dwolla_v2.gemspec
+++ b/dwolla_v2.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "webmock", "~> 3.6"
 
-  spec.add_dependency "hashie", "~> 3.6"
-  spec.add_dependency "faraday", "~> 0.15"
-  spec.add_dependency "faraday_middleware", "~> 0.13"
+  spec.add_dependency "hashie", ">= 3.6"
+  spec.add_dependency "faraday", ">= 0.15"
+  spec.add_dependency "faraday_middleware", ">= 0.13"
 end


### PR DESCRIPTION
This gems dependencies conflict with the Plaid gem due to the strict gem version dependencies.

![Screen Shot 2020-09-02 at 5 07 22 PM](https://user-images.githubusercontent.com/79464/92049257-c65d9b00-ed3e-11ea-8682-23d090fd8e21.png)

![Screen Shot 2020-09-02 at 5 07 36 PM](https://user-images.githubusercontent.com/79464/92049268-ceb5d600-ed3e-11ea-9267-7aa3fe610090.png)
