### PR TITLE
Add MaxNumberOfResourcesError

### DIFF
--- a/lib/dwolla_v2.rb
+++ b/lib/dwolla_v2.rb
@@ -56,6 +56,7 @@ require "dwolla_v2/errors/request_timeout_error"
 require "dwolla_v2/errors/too_many_requests_error"
 require "dwolla_v2/errors/conflict_error"
 require "dwolla_v2/errors/duplicate_resource_error"
+require "dwolla_v2/errors/max_number_of_resources_error"
 
 module DwollaV2
 end

--- a/lib/dwolla_v2/errors/max_number_of_resources_error.rb
+++ b/lib/dwolla_v2/errors/max_number_of_resources_error.rb
@@ -1,0 +1,4 @@
+module DwollaV2
+  class MaxNumberOfResourcesError < Error
+  end
+end

--- a/spec/dwolla_v2/error_spec.rb
+++ b/spec/dwolla_v2/error_spec.rb
@@ -249,6 +249,14 @@ describe DwollaV2::Error do
       expect(e).to be_a DwollaV2::DuplicateResourceError
     }
   end
+
+  it ".raise! code: MaxNumberOfResources" do
+    expect {
+      DwollaV2::Error.raise! code: "MaxNumberOfResources"
+    }.to raise_error {|e|
+      expect(e).to be_a DwollaV2::MaxNumberOfResourcesError
+    }
+  end
   
   it ".raise! Struct(status, headers, body)" do
     status = 400


### PR DESCRIPTION
Add MaxNumberOfResourcesError (which happens when creating a funding source and a customer account has more than the allotted number of active funding sources) with a test case in the errors spec.