### PR TITLE
Fix deprecation warning on Faraday::Connection#authorization

### DIFF
--- a/lib/dwolla_v2/token.rb
+++ b/lib/dwolla_v2/token.rb
@@ -53,7 +53,7 @@ module DwollaV2
 
     def conn
       @conn ||= Faraday.new do |f|
-        f.authorization :Bearer, access_token if access_token
+        f.request :authorization, :Bearer, access_token if access_token
         f.headers[:accept] = "application/vnd.dwolla.v1.hal+json"
         f.request :multipart
         f.request :json


### PR DESCRIPTION
This should fix #59 so library users can update to Faraday v1 with no deprecations reported.

Closes #59