### PR TITLE
Adding '**' to make opts ruby 3.2+ compliant

### DIFF
--- a/lib/dwolla_v2/client.rb
+++ b/lib/dwolla_v2/client.rb
@@ -20,7 +20,7 @@ module DwollaV2
 
     def_delegators :current_token, :get, :post, :delete
 
-    def initialize opts
+    def initialize **opts
       opts[:id] ||= opts[:key]
       raise ArgumentError.new ":key is required" unless opts[:id].is_a? String
       raise ArgumentError.new ":secret is required" unless opts[:secret].is_a? String


### PR DESCRIPTION
https://github.com/Dwolla/dwolla-v2-ruby/blob/980853368696d50b3d1c9e4cea0c310efa662f4e/lib/dwolla_v2/client.rb#L22-L25 is not ruby 3.2+ keywords compliant.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

> Methods taking a rest parameter (like *args) and wishing to delegate keyword arguments through foo(*args) must now be marked with ruby2_keywords (if not already the case). In other words, all methods wishing to delegate keyword arguments through *args must now be marked with ruby2_keywords, with no exception. This will make it easier to transition to other ways of delegation once a library can require Ruby 3+. Previously, the ruby2_keywords flag was kept if the receiving method took *args, but this was a bug and an inconsistency. A good technique to find potentially missing ruby2_keywords is to run the test suite, find the last method which must receive keyword arguments for each place where the test suite fails, and use puts nil, caller, nil there. Then check that each method/block on the call chain which must delegate keywords is correctly marked with ruby2_keywords

To fix we add the '**' before the `opts` parameter and this resolved the issue.