### PR TITLE
Provide support for Faraday 2.0

### DIFF
--- a/dwolla_v2.gemspec
+++ b/dwolla_v2.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.6"
 
   spec.add_dependency "hashie", ">= 3.6"
-  spec.add_dependency "faraday", ">= 0.15"
-  spec.add_dependency "faraday_middleware", ">= 0.13"
+  spec.add_dependency "faraday", "~> 2.0"
+  spec.add_dependency "faraday-multipart"
 end

--- a/lib/dwolla_v2.rb
+++ b/lib/dwolla_v2.rb
@@ -8,7 +8,7 @@ require "time"
 require "hashie"
 
 require "faraday"
-require "faraday_middleware"
+require "faraday/multipart"
 
 require "dwolla_v2/version"
 require "dwolla_v2/client"

--- a/lib/dwolla_v2/client.rb
+++ b/lib/dwolla_v2/client.rb
@@ -58,7 +58,7 @@ module DwollaV2
 
     def conn
       @conn ||= Faraday.new do |f|
-        f.request :basic_auth, id, secret
+        f.request :authorization, :basic, id, secret
         f.request :url_encoded
         f.use SetUserAgent
         f.use HandleErrors


### PR DESCRIPTION
This allows the Dwolla_v2 gem to work with the latest Faraday.